### PR TITLE
Create Override method to Override General GetAllAsync in BookingRepo

### DIFF
--- a/car-booking-service.Application/Services/Implementations/BookingService.cs
+++ b/car-booking-service.Application/Services/Implementations/BookingService.cs
@@ -24,29 +24,7 @@ namespace car_booking_service.Application.Services.Implementations
         public async Task<IEnumerable<BookingResponse>> GetAllBookingAsync()
         {
             IEnumerable<Booking> bookings = await _bookingRepository.GetAllAsync();
-            List<int> carIds = bookings.Select(x => x.CarId).Distinct().ToList();
-            var carModels = await _carModelRepository.GetListByIdsAsync(carIds);
-
-            var result = bookings.Join(carModels, booking => booking.CarId,
-                                                  carModel => carModel.CarId,
-                                                  (booking, carModel) => new BookingResponse()
-                                                  {
-                                                      BookingId = booking.BookingId,
-                                                      CarId = booking.CarId,
-                                                      CarModelBrand = carModel.Brand,
-                                                      CarModelName = carModel.Model,
-                                                      CarModelYear = carModel.Year,
-                                                      BookingDateTime = booking.BookingDateTime,
-                                                      CustomerName = booking.CustomerName,
-                                                      CustomerEmail = booking.CustomerEmail,
-                                                      CustomerPhone = booking.CustomerPhone,
-                                                      CreatedAt = booking.CreatedAt,
-                                                      CreatedBy = booking.CreatedBy,
-                                                      UpdatedAt = booking.UpdatedAt,
-                                                      UpdatedBy = booking.UpdatedBy
-                                                  });
-
-            return result;
+            return bookings.Adapt<IEnumerable<BookingResponse>>();
         }
 
         public async Task<BookingResponse> GetBookingByIdAsync(int id)

--- a/car-booking-service.Infrastructure/Repositories/BookingRepository.cs
+++ b/car-booking-service.Infrastructure/Repositories/BookingRepository.cs
@@ -11,6 +11,33 @@ namespace car_booking_service.Infrastructure.Repositories
         {
         }
 
+
+        public override async Task<IEnumerable<Booking>> GetAllAsync()
+        {
+            return await _context.Bookings.AsNoTracking()
+                                          .Join(
+                                            _context.CarModels.AsNoTracking(),
+                                            booking => booking.CarId,
+                                            carModel => carModel.CarId,
+                                            (booking, carModel) => new Booking
+                                            {
+                                                BookingId = booking.BookingId,
+                                                CarId = carModel.CarId,
+                                                CarModelBrand = carModel.Brand,
+                                                CarModelName = carModel.Model,
+                                                CarModelYear = carModel.Year,
+                                                BookingDateTime = booking.BookingDateTime,
+                                                CustomerName = booking.CustomerName,
+                                                CustomerPhone = booking.CustomerPhone,
+                                                CustomerEmail = booking.CustomerEmail,
+                                                CreatedAt = booking.CreatedAt,
+                                                CreatedBy = booking.CreatedBy,
+                                                UpdatedBy = booking.UpdatedBy,
+                                                UpdatedAt = booking.UpdatedAt
+                                           }).ToListAsync();
+
+        }
+
         public async Task<List<Booking>> GetListAsync(DateTime startDate, 
                                                       DateTime endDate,
                                                       int? carId,
@@ -22,28 +49,28 @@ namespace car_booking_service.Infrastructure.Repositories
                                                       int? carYear = 0)
         {
             var bookingQuery = _context.Bookings.AsNoTracking()
-                                            .Where(x => x.BookingDateTime >= startDate &&
-                                                        x.BookingDateTime <= endDate)
-                                            .Join(
-                                                _context.CarModels.AsNoTracking(),
-                                                booking => booking.CarId,
-                                                carModel => carModel.CarId,
-                                                (booking, carModel) => new Booking
-                                                {
-                                                    BookingId = booking.BookingId,
-                                                    CarId = carModel.CarId,
-                                                    CarModelBrand = carModel.Brand,
-                                                    CarModelName = carModel.Model,
-                                                    CarModelYear = carModel.Year,
-                                                    BookingDateTime = booking.BookingDateTime,
-                                                    CustomerName = booking.CustomerName,
-                                                    CustomerPhone = booking.CustomerPhone,
-                                                    CustomerEmail = booking.CustomerEmail,
-                                                    CreatedAt = booking.CreatedAt,
-                                                    CreatedBy = booking.CreatedBy,
-                                                    UpdatedBy = booking.UpdatedBy,
-                                                    UpdatedAt = booking.UpdatedAt
-                                                });
+                                                .Where(x => x.BookingDateTime >= startDate &&
+                                                            x.BookingDateTime <= endDate)
+                                                .Join(
+                                                    _context.CarModels.AsNoTracking(),
+                                                    booking => booking.CarId,
+                                                    carModel => carModel.CarId,
+                                                    (booking, carModel) => new Booking
+                                                    {
+                                                        BookingId = booking.BookingId,
+                                                        CarId = carModel.CarId,
+                                                        CarModelBrand = carModel.Brand,
+                                                        CarModelName = carModel.Model,
+                                                        CarModelYear = carModel.Year,
+                                                        BookingDateTime = booking.BookingDateTime,
+                                                        CustomerName = booking.CustomerName,
+                                                        CustomerPhone = booking.CustomerPhone,
+                                                        CustomerEmail = booking.CustomerEmail,
+                                                        CreatedAt = booking.CreatedAt,
+                                                        CreatedBy = booking.CreatedBy,
+                                                        UpdatedBy = booking.UpdatedBy,
+                                                        UpdatedAt = booking.UpdatedAt
+                                                    });
 
             if(carId.GetValueOrDefault(0) != 0)
                 bookingQuery = bookingQuery.Where(x => x.CarId == carId);


### PR DESCRIPTION
Create Override method to Override General GetAllAsync in BookingRepo.
It is to simplify GetAllBookingAsync in BookingServices so it won't create 2 connection, but 1 connection only to BookingRepo which already joined to CarModel table, so it wont be a burden for database.